### PR TITLE
Added reverse option for builds >8903

### DIFF
--- a/MORE_INFO.md
+++ b/MORE_INFO.md
@@ -169,3 +169,6 @@ Alternatively, you can export all necessary secrets and run from another host, a
 Please use PowerShell's Get-Help to find even more information on how to use this script!
 
 The script can be found on [Northwave's GitHub](https://github.com/NorthwaveNL/passwordstate-decryptor).
+
+## Builds > 8903
+During update Passwordstate 8.9 - Build 8903 (released April 6th 2020) Clickstudios changed the way data was encrypted/decrypted. For newer versions, the folks at [modzero discovered](https://modzero.com/modlog/archives/2022/12/19/better_make_sure_your_password_manager_is_secure/index.html) that during the update, Clickstudios decided to reverse the encryption key.

--- a/PasswordStateDecryptor.ps1
+++ b/PasswordStateDecryptor.ps1
@@ -49,6 +49,10 @@ function Invoke-PasswordStateDecryptor {
     # use FIPSMode? Default is false.
     $FIPSMode = $false,
 
+    [boolean]
+    # reverse encryption key? Default is false.
+    $Reverse = $false,
+
     [string]
     # The connection string to the database. Default extracts from web.config.
     $ConnectionString,
@@ -140,6 +144,10 @@ function Invoke-PasswordStateDecryptor {
             
             # Combine secrets and return recovered Text String
             $EncryptionKey = [Moserware.Security.Cryptography.SecretCombiner]::Combine($Secret1 + "`n" + $Secret3).RecoveredTextString
+            # For versions >= 8903 the key needs to be reverse
+            if ($Reverse) {
+                $EncryptionKey = $EncryptionKey[-1..-$EncryptionKey.Length ] -join ""
+            }
             Write-Host -ForegroundColor Green "Recovered Encryption Key: $EncryptionKey!"
         }
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # Info
 
-This script will decrypt PasswordState entries for PasswordState versions before Passwordstate 8.9 - Build 8903 (released April 6th 2020). During that update Clickstudios changed the way data was encrypted/decrypted. For newer versions, please refer to https://github.com/NorthwaveSecurity/passwordstate-decryptor/issues/1#issuecomment-1361475213. The folks at modzero discovered that during the update, Clickstudios decided to reverse the encryption key. In their Security Disclosure Report they provide a sample patch for this script to make it work for newer versions. PRs to implement this feature are welcome!
+This script will decrypt PasswordState entries. During update Passwordstate 8.9 - Build 8903 (released April 6th 2020) Clickstudios changed the way data was encrypted/decrypted. For newer versions, the folks at [modzero discovered](https://modzero.com/modlog/archives/2022/12/19/better_make_sure_your_password_manager_is_secure/index.html) that during the update, Clickstudios decided to reverse the encryption key. The script now includes the option to reverse the encryption key before usage.
 
 ## Usage
 
@@ -46,8 +46,7 @@ SYNOPSIS
 
 
 SYNTAX
-    Invoke-PasswordStateDecryptor [[-WebConfig] <String>] [[-SecretSplitterDLL] <String>] [[-FIPSMode] <Boolean>]
-    [[-ConnectionString] <String>] [[-Secret1] <String>] [[-Secret3] <String>] [[-CSVPath] <String>] [[-EncryptionKey]
+    Invoke-PasswordStateDecryptor [[-WebConfig] <String>] [[-SecretSplitterDLL] <String>] [[-FIPSMode] <Boolean>] [[-Reverse] <Boolean>] [[-ConnectionString] <String>] [[-Secret1] <String>] [[-Secret3] <String>] [[-CSVPath] <String>] [[-EncryptionKey]
     <String>] [<CommonParameters>]
 
 


### PR DESCRIPTION
Hi all! I added an option to reverse the encryption key which allows to decrypt Passwordstate entries for versions >= 8903 as requested in issue #1. As I currently do not have access to an installed version of Passwordstate, it would be great if someone could verify it is working as intended.

Cheers!