### PR TITLE
Adding ability to decrypt entries after Build 9700

### DIFF
--- a/MORE_INFO.md
+++ b/MORE_INFO.md
@@ -170,5 +170,16 @@ Please use PowerShell's Get-Help to find even more information on how to use thi
 
 The script can be found on [Northwave's GitHub](https://github.com/NorthwaveNL/passwordstate-decryptor).
 
-## Builds > 8903
+## Builds >= 8903 and < 9700
 During update Passwordstate 8.9 - Build 8903 (released April 6th 2020) Clickstudios changed the way data was encrypted/decrypted. For newer versions, the folks at [modzero discovered](https://modzero.com/modlog/archives/2022/12/19/better_make_sure_your_password_manager_is_secure/index.html) that during the update, Clickstudios decided to reverse the encryption key.
+
+## Builds >= 9700
+In update Passwordstate 9.7 - Build 9700 (released 7th February 2023) Clickstudios again changed the way encryption keys were derived. The folks at [Division 5 discovered](https://division5.io/decrypting-passwordstate) that encryption keys were derived via HMAC-SHA256, thus using all four secret parts.
+
+The following table best summarises the encryption methods:
+
+| Versions | Encryption Key Derivation Method |
+| --- | --- |
+| x < 8903  | `join(Secret1, Secret3)` |
+| 8903 <= x < 9700 | `reverse(join(Secret1, Secret3))` |
+| 9700 <= x | `HMAC(alg=SHA256, key=join(Secret2, Secret4), plaintext=join(Secret1, Secret3))` |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # Info
 
-This script will decrypt PasswordState entries. During update Passwordstate 8.9 - Build 8903 (released April 6th 2020) Clickstudios changed the way data was encrypted/decrypted. For newer versions, the folks at [modzero discovered](https://modzero.com/modlog/archives/2022/12/19/better_make_sure_your_password_manager_is_secure/index.html) that during the update, Clickstudios decided to reverse the encryption key. The script now includes the option to reverse the encryption key before usage.
+This script will decrypt PasswordState entries. During update Passwordstate 8.9 - Build 8903 (released April 6th 2020) Clickstudios changed the way encryption keys were derived. The folks at [modzero discovered](https://modzero.com/modlog/archives/2022/12/19/better_make_sure_your_password_manager_is_secure/index.html) that during the update, Clickstudios decided to reverse the encryption key. In update Passwordstate 9.7 - Build 9700 (released 7th February 2023) Clickstudios again changed the way encryption keys were derived. The folks at [Division 5 discovered](https://division5.io/decrypting-passwordstate) that encryption keys were derived via HMAC-SHA256. This script now includes a build number flag, which will use the correct key derivation algorithm depending on the build number.
 
 ## Usage
 
@@ -46,8 +46,9 @@ SYNOPSIS
 
 
 SYNTAX
-    Invoke-PasswordStateDecryptor [[-WebConfig] <String>] [[-SecretSplitterDLL] <String>] [[-FIPSMode] <Boolean>] [[-Reverse] <Boolean>] [[-ConnectionString] <String>] [[-Secret1] <String>] [[-Secret3] <String>] [[-CSVPath] <String>] [[-EncryptionKey]
-    <String>] [<CommonParameters>]
+    Invoke-PasswordStateDecryptor [[-WebConfig] <String>] [[-SecretSplitterDLL] <String>] [[-FIPSMode] <Boolean>]
+    [[-ConnectionString] <String>] [[-Secret1] <String>] [[-Secret2] <String>] [[-Secret3] <String>] [[-Secret4] <String>]
+    [[-CSVPath] <String>] [[-EncryptionKey] <String>] [[-BuildNo] <Int32>] [<CommonParameters>]
 
 
 DESCRIPTION
@@ -60,8 +61,8 @@ DESCRIPTION
         * Moserware.SecretSplitter.dll somewhere (shipped in the repo or on the disk)
     An example of such a host is the PasswordState server itself.
 
-    Alternatively, if you are able to compromise the database, export all entries to CSV
-    and the secret1 and secret3 or the encryption key, you can use the script offline. The
+    Alternatively, if you are able to compromise the database, export all entries to CSV, the build number
+    and the secret1, secret2, secret3 and secret4 values or the encryption key, you can use the script offline. The
     CSV should contain (at least) the following fields: UserName, Password, Description and Title
 
 


### PR DESCRIPTION
This adds the ability to decrypt Passwordstate entries after Build 9700. The script now pulls a bit more information from the database/web.config file and forms the decryption key based on the build number (retrieved from the database or can be manually specified). Thanks!